### PR TITLE
Add Jest setup and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "javascript-quiz-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -110,3 +110,6 @@ const questions = [
     ]
   }
 ]
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { setStatusClass, clearStatusClass };
+}

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -1,0 +1,26 @@
+const { setStatusClass } = require('../script');
+
+function createMockElement() {
+  return {
+    classList: {
+      classes: new Set(),
+      add(cls) { this.classes.add(cls); },
+      remove(cls) { this.classes.delete(cls); },
+      contains(cls) { return this.classes.has(cls); }
+    }
+  };
+}
+
+test('applies correct class when correct is true', () => {
+  const el = createMockElement();
+  setStatusClass(el, true);
+  expect(el.classList.contains('correct')).toBe(true);
+  expect(el.classList.contains('wrong')).toBe(false);
+});
+
+test('applies wrong class when correct is false', () => {
+  const el = createMockElement();
+  setStatusClass(el, false);
+  expect(el.classList.contains('wrong')).toBe(true);
+  expect(el.classList.contains('correct')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and test script
- export functions for testing
- add unit tests for `setStatusClass`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840401a36b08321af361f933c910983