### PR TITLE
Fix restart button text

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ nextButton.addEventListener('click', () => {
 })
 
 function startGame() {
+  startButton.innerText = "Start"
   startButton.classList.add('hide')
   shuffledQuestions = questions.sort(() => Math.random() - .5)
   currentQuestionIndex = 0
@@ -109,4 +110,4 @@ const questions = [
       { text: '8', correct: true }
     ]
   }
-]
+];


### PR DESCRIPTION
## Summary
- ensure the start button text resets to `Start` whenever a new game begins
- add the missing semicolon at the end of `questions` array

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68403f6a79188321b94f18af1f86cf99